### PR TITLE
Cleanup

### DIFF
--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
@@ -187,34 +187,32 @@ public class JobView {
 
     @JsonProperty
     public boolean shouldVisualizeChangeLog() {
-        if (job.getLastBuild() == null) // no builds whatsoever
-            return false;
-
-        if (config.getChangeSetVisualization() == Config.ChangeSetVisualizationType.Hidden)
-            return false;
-
-        if (config.getChangeSetVisualization() == Config.ChangeSetVisualizationType.NextBuildOnly && !lastBuild().isRunning())
-            return false;
-
-        return true;
+        switch (config.getChangeSetVisualization()) {
+            case LastOrNextBuild:
+                return job.getLastBuild() != null || lastBuild().isRunning();
+            case NextBuildOnly:
+                return lastBuild().isRunning();
+            case LastBuildOnly:
+                return job.getLastBuild() != null;
+            case Hidden:
+            default:
+                return false;
+        }
     }
 
     @JsonProperty
     public List<String> changeLog() {
-        BuildViewModel buildForChangeLogFetching = getBuildForChangeLogFetching();
-        return buildForChangeLogFetching != null ? buildForChangeLogFetching.changeLog() : null;
+        return getBuildForChangeLogFetching().changeLog();
     }
 
     @JsonProperty
     public boolean hasChangeLogComputed() {
-        BuildViewModel buildForChangeLogFetching = getBuildForChangeLogFetching();
-        return buildForChangeLogFetching != null && buildForChangeLogFetching.hasChangeLogComputed();
+        return getBuildForChangeLogFetching().hasChangeLogComputed();
     }
 
     @JsonProperty
     public boolean isChangeLogForUpcomingBuild() {
-        BuildViewModel buildForChangeLogFetching = getBuildForChangeLogFetching();
-        return buildForChangeLogFetching != null && buildForChangeLogFetching.isRunning();
+        return getBuildForChangeLogFetching().isRunning();
     }
 
     private BuildViewModel getBuildForChangeLogFetching() {
@@ -226,7 +224,7 @@ public class JobView {
                 return lastCompletedBuild();
             case Hidden:
             default:
-                return null;
+                return new NullBuildView();
         }
     }
 

--- a/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/widgets.jelly
+++ b/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/widgets.jelly
@@ -34,7 +34,7 @@
                         <span>
                             <ng-pluralize data-ng-show="!project.changeLogForUpcomingBuild"
                                 count="project.changeLog.length"
-                                when="{'0': 'No changes since last build', '1': 'Changes in build: ', 'other': '{{ project.changeLog.length }} changes in build: '}"></ng-pluralize>
+                                when="{'0': 'No changes since last build', '1': 'Change in build: ', 'other': '{{ project.changeLog.length }} changes in build: '}"></ng-pluralize>
                             <ng-pluralize data-ng-show="!!project.changeLogForUpcomingBuild"
                                 count="project.changeLog.length"
                                 when="{'0': 'No changes in upcoming build', '1': 'Change in upcoming build: ', 'other': '{{ project.changeLog.length }} changes in upcoming build: '}"></ng-pluralize>


### PR DESCRIPTION
Cleanup - use null views instead of actual nulls where appropriate,
also fix first build’s status output
